### PR TITLE
Add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,11 @@ repos:
           - mdformat-gfm
           - mdformat-toc
 
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.8.12
+    hooks:
+      - id: gitleaks
+
   - repo: local
     hooks:
       - id: no-todo


### PR DESCRIPTION
- Add gitleaks pre-commit hook

(If secrets are ever committed to git, even locally, they must be rotated)